### PR TITLE
feat: add memory_used_gb and memory_total_gb to JSON report

### DIFF
--- a/src/nvsonar/report/json.py
+++ b/src/nvsonar/report/json.py
@@ -31,6 +31,8 @@ def build_report(
             "memory_utilization": metrics.memory_utilization,
             "memory_used_mb": metrics.memory_used // (1024 ** 2),
             "memory_total_mb": metrics.memory_total // (1024 ** 2),
+            "memory_used_gb": round(metrics.memory_used / (1024 ** 3), 1),
+            "memory_total_gb": round(metrics.memory_total / (1024 ** 3), 1),
             "memory_used_pct": round(metrics.memory_used_pct, 1),
             "gpu_clock_mhz": metrics.gpu_clock,
             "max_gpu_clock_mhz": metrics.max_gpu_clock,


### PR DESCRIPTION
## Summary
- Add `memory_used_gb` and `memory_total_gb` fields (rounded to 1 decimal) to the JSON report metrics section
- Existing MB fields are preserved for backward compatibility

## Example output
```json
"metrics": {
  "memory_used_mb": 4096,
  "memory_total_mb": 24576,
  "memory_used_gb": 4.0,
  "memory_total_gb": 24.0,
  ...
}
```

## Test plan
- [ ] `nvsonar report --json` includes `memory_used_gb` and `memory_total_gb`
- [ ] GB values are correctly rounded to 1 decimal
- [ ] Existing MB fields remain unchanged

Closes #14