### PR TITLE
feat: show GPU driver and CUDA version in report card

### DIFF
--- a/src/nvsonar/report/card.py
+++ b/src/nvsonar/report/card.py
@@ -127,6 +127,8 @@ def print_report(
     table.add_column(style="dim", width=20)
     table.add_column()
 
+    table.add_row("Driver", gpu_info.driver_version)
+    table.add_row("CUDA", gpu_info.cuda_version)
     table.add_row("GPU utilization", f"{metrics.gpu_utilization}%")
     table.add_row("Memory controller", f"{metrics.memory_utilization}%")
     table.add_row(


### PR DESCRIPTION
## Summary
- Add Driver and CUDA version rows to the terminal report card metrics table
- Data is already collected in `GPUInfo` — this just displays it in `report/card.py`

## Test plan
- [ ] `nvsonar report` shows Driver and CUDA version rows in the report card
- [ ] Values match `nvidia-smi` output

Closes #13