### PR TITLE
fix: add total VRAM to JSON output in GB

### DIFF
--- a/src/nvsonar/report/json.py
+++ b/src/nvsonar/report/json.py
@@ -31,6 +31,8 @@ def build_report(
             "memory_utilization": metrics.memory_utilization,
             "memory_used_mb": metrics.memory_used // (1024 ** 2),
             "memory_total_mb": metrics.memory_total // (1024 ** 2),
+            "memory_used_gb": round(metrics.memory_used / (1024 ** 3), 1),
+            "memory_total_gb": round(metrics.memory_total / (1024 ** 3), 1),
             "memory_used_pct": round(metrics.memory_used_pct, 1),
             "gpu_clock_mhz": metrics.gpu_clock,
             "max_gpu_clock_mhz": metrics.max_gpu_clock,


### PR DESCRIPTION
This PR adds `memory_used_gb` and `memory_total_gb` fields rounded to 1 decimal to the JSON report output metrics section. This makes it easier to read the VRAM usage for GPUs with large memory capacity.

Fixes #14