### PR TITLE
feat: add CSV export for report output

### DIFF
--- a/src/nvsonar/cli.py
+++ b/src/nvsonar/cli.py
@@ -30,12 +30,13 @@ def main(ctx: typer.Context):
 @app.command()
 def report(
     json: bool = typer.Option(False, "--json", help="Output as JSON"),
+    csv: bool = typer.Option(False, "--csv", help="Output as CSV"),
     gpu: int = typer.Option(-1, "--gpu", help="GPU index, -1 for all"),
 ):
     """One-shot GPU diagnostic report"""
     from nvsonar.monitor import initialize, get_device_count, get_gpu_info, MetricsCollector
     from nvsonar.analysis import classify, detect_outliers, recommend
-    from nvsonar.report import print_report, to_json
+    from nvsonar.report import print_report, to_json, report_to_csv_row, to_csv
 
     if not initialize():
         typer.echo("Error: failed to initialize NVML, no NVIDIA GPU found", err=True)
@@ -90,6 +91,16 @@ def report(
             typer.echo(json_reports[0])
         else:
             typer.echo("[" + ",\n".join(json_reports) + "]")
+    elif csv:
+        csv_rows = []
+        for i in indices:
+            info = get_gpu_info(i)
+            if not info:
+                continue
+            metrics = all_metrics[i]
+            bottleneck = classify(metrics)
+            csv_rows.append(report_to_csv_row(info, metrics, bottleneck))
+        typer.echo(to_csv(csv_rows))
 
 
 if __name__ == "__main__":

--- a/src/nvsonar/report/__init__.py
+++ b/src/nvsonar/report/__init__.py
@@ -1,8 +1,11 @@
 from .card import print_report
+from .csv_report import report_to_csv_row, to_csv
 from .json import build_report, to_json
 
 __all__ = [
     "print_report",
+    "report_to_csv_row",
+    "to_csv",
     "build_report",
     "to_json",
 ]

--- a/src/nvsonar/report/csv_report.py
+++ b/src/nvsonar/report/csv_report.py
@@ -1,0 +1,97 @@
+"""CSV report output for nvsonar"""
+
+import csv
+import io
+
+from nvsonar.monitor import Metrics
+from nvsonar.monitor.hardware import GPUInfo
+from nvsonar.analysis.bottleneck import BottleneckResult
+from nvsonar.report.json import build_report
+
+CSV_FIELDS = [
+    "gpu_index",
+    "gpu_name",
+    "uuid",
+    "driver_version",
+    "cuda_version",
+    "gpu_utilization",
+    "memory_utilization",
+    "memory_used_mb",
+    "memory_total_mb",
+    "memory_used_pct",
+    "gpu_clock_mhz",
+    "max_gpu_clock_mhz",
+    "clock_reduction_pct",
+    "temperature_c",
+    "power_usage_w",
+    "power_limit_w",
+    "power_used_pct",
+    "fan_speed_pct",
+    "is_throttled",
+    "throttle_severity",
+    "pcie_gen",
+    "pcie_width",
+    "pcie_degraded",
+    "ecc_enabled",
+    "ecc_correctable",
+    "ecc_uncorrectable",
+    "bottleneck",
+    "bottleneck_confidence",
+    "bottleneck_detail",
+]
+
+
+def report_to_csv_row(
+    gpu_info: GPUInfo,
+    metrics: Metrics,
+    bottleneck: BottleneckResult,
+) -> dict:
+    """Build a flat dict suitable for CSV output."""
+    report = build_report(gpu_info, metrics, bottleneck)
+    gpu = report["gpu"]
+    m = report["metrics"]
+    th = report["throttle"]
+    pcie = report["pcie"]
+    ecc = report["ecc"]
+    analysis = report["analysis"]
+
+    return {
+        "gpu_index": gpu["index"],
+        "gpu_name": gpu["name"],
+        "uuid": gpu["uuid"],
+        "driver_version": gpu["driver"],
+        "cuda_version": gpu["cuda"],
+        "gpu_utilization": m["gpu_utilization"],
+        "memory_utilization": m["memory_utilization"],
+        "memory_used_mb": m["memory_used_mb"],
+        "memory_total_mb": m["memory_total_mb"],
+        "memory_used_pct": m["memory_used_pct"],
+        "gpu_clock_mhz": m["gpu_clock_mhz"],
+        "max_gpu_clock_mhz": m["max_gpu_clock_mhz"],
+        "clock_reduction_pct": m["clock_reduction_pct"],
+        "temperature_c": m["temperature_c"],
+        "power_usage_w": m["power_usage_w"],
+        "power_limit_w": m["power_limit_w"],
+        "power_used_pct": m["power_used_pct"],
+        "fan_speed_pct": m["fan_speed_pct"],
+        "is_throttled": th["is_throttled"],
+        "throttle_severity": th["worst_severity"],
+        "pcie_gen": f"{pcie['current_gen']}/{pcie['max_gen']}",
+        "pcie_width": f"x{pcie['current_width']}/x{pcie['max_width']}",
+        "pcie_degraded": pcie["is_degraded"],
+        "ecc_enabled": ecc["enabled"],
+        "ecc_correctable": ecc["correctable"],
+        "ecc_uncorrectable": ecc["uncorrectable"],
+        "bottleneck": analysis["bottleneck"],
+        "bottleneck_confidence": analysis["confidence"],
+        "bottleneck_detail": analysis["detail"],
+    }
+
+
+def to_csv(rows: list[dict]) -> str:
+    """Serialize rows to CSV string with header."""
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=CSV_FIELDS, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()


### PR DESCRIPTION
## Summary

Add `--csv` flag to the `report` command that outputs GPU metrics in CSV format with a header row.

## Problem

JSON output is available but CSV is more convenient for spreadsheets and quick data analysis (issue #11).

## Solution

- New `--csv` flag on `nvsonar report`
- One row per GPU with 29 columns of key metrics
- Header row included for easy parsing with standard CSV tools

## Output Columns

gpu_index, gpu_name, uuid, driver_version, cuda_version, gpu_utilization, memory_utilization, memory_used_mb, memory_total_mb, memory_used_pct, gpu_clock_mhz, max_gpu_clock_mhz, clock_reduction_pct, temperature_c, power_usage_w, power_limit_w, power_used_pct, fan_speed_pct, is_throttled, throttle_severity, pcie_gen, pcie_width, pcie_degraded, ecc_enabled, ecc_correctable, ecc_uncorrectable, bottleneck, bottleneck_confidence, bottleneck_detail

## Usage

```bash
# Single GPU
nvsonar report --csv

# Pipe to file
nvsonar report --csv > gpu_report.csv

# Specific GPU
nvsonar report --csv --gpu 0
```

## Changes

- `src/nvsonar/report/csv_report.py` — New module with `report_to_csv_row()` and `to_csv()`
- `src/nvsonar/report/__init__.py` — Export new functions
- `src/nvsonar/cli.py` — Add `--csv` flag and CSV output logic

Fixes #11