### PR TITLE
Add GPU process list to report

### DIFF
--- a/src/nvsonar/monitor/__init__.py
+++ b/src/nvsonar/monitor/__init__.py
@@ -2,11 +2,13 @@ from .hardware import (
     GPUInfo,
     PCIeInfo,
     ECCInfo,
+    GPUProcess,
     initialize,
     get_device_count,
     get_gpu_info,
     list_gpus,
     get_handle,
+    get_gpu_processes,
 )
 from .metrics import Metrics, MetricsCollector
 from .throttle import ThrottleStatus, ThrottleReason, decode_throttle_reasons
@@ -15,6 +17,7 @@ __all__ = [
     "GPUInfo",
     "PCIeInfo",
     "ECCInfo",
+    "GPUProcess",
     "Metrics",
     "MetricsCollector",
     "ThrottleStatus",
@@ -24,5 +27,6 @@ __all__ = [
     "get_gpu_info",
     "list_gpus",
     "get_handle",
+    "get_gpu_processes",
     "decode_throttle_reasons",
 ]

--- a/src/nvsonar/monitor/hardware.py
+++ b/src/nvsonar/monitor/hardware.py
@@ -1,5 +1,6 @@
 """GPU hardware detection and PCIe/ECC diagnostics"""
 
+import os
 from dataclasses import dataclass
 
 import pynvml as nvml
@@ -97,6 +98,15 @@ class ECCInfo:
     @property
     def has_errors(self) -> bool:
         return self.correctable > 0 or self.uncorrectable > 0
+
+
+@dataclass
+class GPUProcess:
+    """A compute process running on the GPU"""
+
+    pid: int
+    name: str
+    used_memory: int  # bytes
 
 
 def get_handle(device_index: int):
@@ -247,3 +257,21 @@ def get_ecc_info(handle) -> ECCInfo:
         uncorrectable=uncorrectable,
         ecc_enabled=ecc_enabled,
     )
+
+
+def get_gpu_processes(handle) -> list[GPUProcess]:
+    """Get compute processes currently running on a GPU"""
+    try:
+        procs = nvml.nvmlDeviceGetComputeRunningProcesses(handle)
+    except nvml.NVMLError:
+        return []
+
+    result = []
+    for p in procs:
+        try:
+            name = os.path.basename(_decode(nvml.nvmlSystemGetProcessName(p.pid)))
+        except nvml.NVMLError:
+            name = "unknown"
+        used_mem = p.usedGpuMemory if p.usedGpuMemory is not None else 0
+        result.append(GPUProcess(pid=p.pid, name=name, used_memory=used_mem))
+    return result

--- a/src/nvsonar/monitor/metrics.py
+++ b/src/nvsonar/monitor/metrics.py
@@ -1,10 +1,10 @@
 """GPU metrics collection via NVML"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pynvml as nvml
 
-from .hardware import get_handle, get_pcie_info, get_ecc_info, PCIeInfo, ECCInfo
+from .hardware import get_handle, get_pcie_info, get_ecc_info, get_gpu_processes, PCIeInfo, ECCInfo, GPUProcess
 from .throttle import decode_throttle_reasons, ThrottleStatus
 
 
@@ -43,6 +43,9 @@ class Metrics:
 
     # ECC
     ecc: ECCInfo
+
+    # Processes
+    processes: list[GPUProcess] = field(default_factory=list)
 
     @property
     def memory_used_pct(self) -> float:
@@ -139,6 +142,7 @@ class MetricsCollector:
         throttle = decode_throttle_reasons(h)
         pcie = get_pcie_info(h)
         ecc = get_ecc_info(h)
+        processes = get_gpu_processes(h)
 
         return Metrics(
             gpu_utilization=gpu_util,
@@ -155,4 +159,5 @@ class MetricsCollector:
             throttle=throttle,
             pcie=pcie,
             ecc=ecc,
+            processes=processes,
         )

--- a/src/nvsonar/report/card.py
+++ b/src/nvsonar/report/card.py
@@ -203,4 +203,14 @@ def print_report(
             for action in rec.actions:
                 content.add_row(Text(f"      - {action}", style="dim"))
 
+    # processes
+    content.add_row(Text())
+    content.add_row(Text("  Processes:", style="bold"))
+    if metrics.processes:
+        for proc in metrics.processes:
+            mem_mb = proc.used_memory // (1024 ** 2)
+            content.add_row(Text(f"    PID {proc.pid:<8} {proc.name:<24} {mem_mb} MB", style="dim"))
+    else:
+        content.add_row(Text("    (none)", style="dim"))
+
     console.print(Panel(content, title=header, border_style=grade_color))

--- a/src/nvsonar/report/json.py
+++ b/src/nvsonar/report/json.py
@@ -90,6 +90,14 @@ def build_report(
             }
             for r in (recommendations or [])
         ],
+        "processes": [
+            {
+                "pid": p.pid,
+                "name": p.name,
+                "used_memory_mb": p.used_memory // (1024 ** 2),
+            }
+            for p in metrics.processes
+        ],
     }
 
 


### PR DESCRIPTION
Closes #21

## Changes

- `monitor/hardware.py`: added `GPUProcess` dataclass and `get_gpu_processes()` using `nvmlDeviceGetComputeRunningProcesses`
- `monitor/metrics.py`: added `processes: list[GPUProcess]` field to `Metrics`, collected in `MetricsCollector.collect()`
- `monitor/__init__.py`: exported `GPUProcess` and `get_gpu_processes`
- `report/card.py`: added Processes section showing PID, executable name, and VRAM usage
- `report/json.py`: added `"processes"` key to the JSON output

## Behavior

- `nvsonar report` shows a Processes section (displays `(none)` when the GPU is idle)
- `nvsonar report --json` includes a `processes` array with `pid`, `name`, and `used_memory_mb`